### PR TITLE
Update for osg-htc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Note: We hope to return to an in-person OSG User School in 2022!
 ## Contact Us
 
 The OSG Virtual School is part of the
-[OSG Outreach Area](https://opensciencegrid.org/outreach/)&nbsp;&mdash; please visit that site to
+[OSG Outreach Area](https://osg-htc.org/outreach/)&nbsp;&mdash; please visit that site to
 learn about past OSG Schools.
 
 If you have any questions about the event, feel free to email us:


### PR DESCRIPTION
All opensciencegrid.org/** websites have been moved so this is the final clean up of existing pointers to the previous locations.

Another pass will be done in the future to clean up **.opensciencegrid.org subdomains when they are transferred.